### PR TITLE
chore: redirect to product page from home page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+    async redirects() {
+        return [
+          {
+            source: '/',
+            destination: '/en/product/',
+            permanent: true,
+          },
+        ]
+      },
+}
 
 module.exports = nextConfig


### PR DESCRIPTION
# What are these changes for
 - These changes are for redirecting from the home page to `/en/product/` page, mainly this was done to speed up the page opening after starting the application and making the product page main page for now.

# What are the changes
- `next.config.js` file was updated with a redirects function to redirect from `/` url to `/en/product/`